### PR TITLE
fix ODT export error when 1. the field value is an int type, 2. has &…

### DIFF
--- a/src/Traits/OpenDocumentTextTemplateTrait.php
+++ b/src/Traits/OpenDocumentTextTemplateTrait.php
@@ -33,19 +33,19 @@ trait OpenDocumentTextTemplateTrait
             ->addParagraphStyle(
                 'pRecordMetadata', [
                     'spacing' => 240,
-                    'indent' => 240,
+                    'indent' => 3,
                     'keepNext' => true,
                 ]
             );
         $this->openDocument
             ->addFontStyle(
                 'recordLabel',
-                ['name' => 'Arial', 'size' => 12, 'color' => '1B2232', 'bold' => true]
+                ['name' => 'Arial', 'size' => 11, 'color' => '1B2232', 'bold' => true]
             );
         $this->openDocument
             ->addFontStyle(
                 'recordMetadata',
-                ['name' => 'Arial', 'size' => 12]
+                ['name' => 'Arial', 'size' => 9]
             );
 
         $this->openDocument->getDocInfo()
@@ -88,6 +88,14 @@ trait OpenDocumentTextTemplateTrait
             }
             $section->addText($fieldName, 'recordLabel', 'pRecordLabel');
             foreach ($fieldValues as $fieldValue) {
+                if (is_int($fieldValue)) {
+                   $fieldValue = strval($fieldValue);
+                }
+                if (is_string($fieldValue) && (str_contains($fieldValue, '&') || str_contains($fieldValue, '<'))) {
+                    $patterns = array('/&/', '/</');
+                    $replacements = array('&amp;', '&lt;');
+                    $fieldValue = preg_replace($patterns, $replacements, $fieldValue);
+                }
                 $fieldValue = strip_tags($fieldValue);
                 if (mb_strlen($fieldValue) < 1000) {
                     $section->addText($fieldValue, 'recordMetadata', 'pRecordMetadata');


### PR DESCRIPTION
Fix ODT exporting error:

1.  the value of $fieldValue could be an int type which causes error for strip_tags(), so converting it to string type when it is an int type.
2.  when the value of $fieldValue has `'&'` or `'<'` special characters, the exported ODT file is corrupted, so, replace them to `'&amp;'` and `'&lt;'`, respectively.
3. the indent for paragraph style of record metadata is 240 which is so big, causing the texts outside the odt file, so, change indent to 3. Also, reduced the font sizes a bit.