### PR TITLE
Close curly brackets in ExporterRepresentation.php

### DIFF
--- a/src/Api/Representation/ExporterRepresentation.php
+++ b/src/Api/Representation/ExporterRepresentation.php
@@ -96,6 +96,7 @@ class ExporterRepresentation extends AbstractEntityRepresentation
         $manager = $this->getWriterManager();
         if (!$manager->has($writerClass)) {
             return null;
+        }
 
         $this->writer = $manager->get($writerClass);
         if ($this->writer instanceof Configurable) {


### PR DESCRIPTION
I got the following error after installing this module in Omeka 4.1.0 :

ParseError: syntax error, unexpected token "protected" in /var/www/html/modules/BulkExport/src/Api/Representation/ExporterRepresentation.php:112

I think I found an unclosed if-block.